### PR TITLE
allowed config_dir to be read from the ~/.avst-cloud.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Supported options are
 * server_config_url_username, server_config_url_password - if --server_config_url option is used
 * confluence_url, confluence_user, confluence_access_password, confluence_space, confluence_parent_page_id - to setup confluence_reporter
 * provider_username, provider_password, region - provider credentials and region
+* config_dir
 
 ## Minimal Configuration
 

--- a/bin/avst-cloud-runner
+++ b/bin/avst-cloud-runner
@@ -667,7 +667,7 @@ end
 @logger = Logger.new($stdout)
 @global_config = {}
 if File.exists? ("#{ENV['HOME']}/.avst-cloud.yaml")
-    @global_config = YAML.load(File.read("#{ENV['HOME']}/.avst-cloud.yaml"))
+    @global_config = YAML.load(File.read("#{ENV['HOME']}/.avst-cloud.yaml")) || {}
 end
 
 begin
@@ -763,8 +763,8 @@ begin
       "::customer_short_code" => customer_short_code,
     }
 
-    # if there is a custom data dir use it, otherwide use base
-    avst_cloud_config_dir = options["--config_dir"] || "#{avst_cloud_base}/config"
+    # if there is a custom data dir use it, otherwise use base
+    avst_cloud_config_dir = options["--config_dir"] || @global_config['config_dir'] || "#{avst_cloud_base}/config"
     @avst_cloud_config_dir = avst_cloud_config_dir
 
     # create fully qualified hiera.yaml based on template, to be able to refer to config/hiera

--- a/lib/avst-cloud-runner/version.rb
+++ b/lib/avst-cloud-runner/version.rb
@@ -1,3 +1,3 @@
 module AvstCloudRunner
-  VERSION = "0.1.15"
+  VERSION = "0.1.16"
 end


### PR DESCRIPTION
This allows for a custom config dir to be user but for a user to set it as their default so they do not need to keep passing in the --config_dir <blah> value